### PR TITLE
Integrate AI powered meal plan ranking

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -37,6 +37,22 @@ async function seedAdminUser() {
 }
 
 dotenv.config();
+
+const OPENAI_ENV_KEY =
+  process.env.OPENAI_API_KEY ||
+  process.env.AI_OPENAI_API_KEY ||
+  process.env.AI_API_KEY ||
+  "";
+
+if (OPENAI_ENV_KEY && !process.env.OPENAI_API_KEY) {
+  process.env.OPENAI_API_KEY = OPENAI_ENV_KEY;
+}
+
+if (!process.env.OPENAI_API_KEY) {
+  console.warn(
+    "[server] OPENAI_API_KEY is not set. AI powered meal plan ranking will be disabled."
+  );
+}
 const app = express();
 
 // CORS - allow local dev origins and file:// (treated as 'null' origin)

--- a/backend/services/aiMealPlanRanker.js
+++ b/backend/services/aiMealPlanRanker.js
@@ -1,0 +1,179 @@
+const DEFAULT_MODEL = process.env.AI_MEAL_PLAN_MODEL || process.env.OPENAI_MODEL || "gpt-4o-mini";
+const DEFAULT_TEMPERATURE = Number(process.env.AI_MEAL_PLAN_TEMPERATURE ?? "0.2");
+
+let OpenAIConstructor = null;
+try {
+  ({ OpenAI: OpenAIConstructor } = require("openai"));
+} catch (err) {
+  if (process.env.NODE_ENV !== "test") {
+    console.warn(
+      "[aiMealPlanRanker] OpenAI SDK is not available. Install 'openai' to enable AI ranking."
+    );
+  }
+}
+
+let cachedClient = null;
+
+function getClient() {
+  if (!OpenAIConstructor) {
+    throw new Error("OpenAI SDK is not installed.");
+  }
+
+  if (!cachedClient) {
+    const apiKey =
+      process.env.OPENAI_API_KEY ||
+      process.env.AI_OPENAI_API_KEY ||
+      process.env.AI_API_KEY;
+
+    if (!apiKey) {
+      throw new Error("Missing OPENAI_API_KEY environment variable.");
+    }
+
+    cachedClient = new OpenAIConstructor({
+      apiKey,
+      baseURL:
+        process.env.OPENAI_BASE_URL ||
+        process.env.AI_OPENAI_BASE_URL ||
+        process.env.AI_API_BASE_URL,
+    });
+  }
+
+  return cachedClient;
+}
+
+function buildProfileSummary(profile = {}) {
+  if (!profile) return "- No active profile found.";
+
+  const segments = [];
+  if (profile.name) segments.push(`Name: ${profile.name}`);
+  if (profile.age != null) segments.push(`Age: ${profile.age}`);
+  if (profile.gender) segments.push(`Gender: ${profile.gender}`);
+  if (profile.goal) segments.push(`Goal: ${profile.goal}`);
+  if (profile.calorieTarget)
+    segments.push(`Calorie target: ${profile.calorieTarget}`);
+
+  const preferences = Array.isArray(profile.dietaryPreferences)
+    ? profile.dietaryPreferences.filter(Boolean)
+    : [];
+  if (preferences.length) {
+    segments.push(`Dietary preferences: ${preferences.join(", ")}`);
+  }
+
+  if (profile.allergies?.length) {
+    segments.push(`Allergies: ${profile.allergies.join(", ")}`);
+  }
+
+  if (!segments.length) {
+    return "- Minimal profile information available.";
+  }
+
+  return `- ${segments.join("; ")}.`;
+}
+
+function describeMealPlan(plan, index) {
+  const macros = [];
+  if (plan.calories != null) macros.push(`Calories: ${plan.calories}`);
+  if (plan.protein != null) macros.push(`Protein: ${plan.protein}g`);
+  if (plan.fat != null) macros.push(`Fat: ${plan.fat}g`);
+  if (plan.carbs != null) macros.push(`Carbs: ${plan.carbs}g`);
+
+  const description = [
+    `${index + 1}. ID: ${plan._id}`,
+    `Title: ${plan.title || "Untitled"}`,
+    `Goal type: ${plan.goalType || "unspecified"}`,
+    `Diet tags: ${(plan.dietTags || []).join(", ") || "none"}`,
+    `Macros: ${macros.join(", ") || "not provided"}`,
+    `Description: ${plan.description || "No description."}`,
+  ];
+
+  return description.join("\n");
+}
+
+function buildPrompt({ profile, candidates }) {
+  const profileSummary = buildProfileSummary(profile);
+  const plansSummary = candidates
+    .map((plan, index) => describeMealPlan(plan, index))
+    .join("\n\n");
+
+  return `You are an expert nutrition coach. Rank the following meal plans for the user profile provided. Respond with strict JSON matching this schema:\n\n{\n  "rankings": [\n    { "id": "<mealPlanId>", "rationale": "<why this plan suits the user>" }\n  ]\n}\n\nOnly include IDs from the candidate list. Provide succinct rationales (1-2 sentences).\n\nUser profile:\n${profileSummary}\n\nMeal plans:\n${plansSummary}`;
+}
+
+function extractTextFromResponse(response) {
+  if (!response) return "";
+
+  if (typeof response.output_text === "string") {
+    return response.output_text;
+  }
+
+  const output = Array.isArray(response.output) ? response.output : [];
+  const textChunks = output
+    .flatMap((item) => item?.content || [])
+    .filter((piece) => piece?.type === "output_text" || piece?.type === "text")
+    .map((piece) => piece.text || piece.value)
+    .filter(Boolean);
+
+  return textChunks.join("\n");
+}
+
+function safeParseRankings(text) {
+  if (!text) return [];
+
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : text);
+    if (!parsed || !Array.isArray(parsed.rankings)) return [];
+
+    return parsed.rankings
+      .map((entry) => {
+        if (typeof entry === "string") {
+          return { id: entry };
+        }
+        if (!entry || !entry.id) return null;
+        return { id: entry.id, rationale: entry.rationale || null };
+      })
+      .filter(Boolean);
+  } catch (err) {
+    return [];
+  }
+}
+
+async function rankMealPlans({ profile, candidates } = {}) {
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return [];
+  }
+
+  const client = getClient();
+  const prompt = buildPrompt({ profile, candidates });
+
+  const response = await client.responses.create({
+    model: DEFAULT_MODEL,
+    input: [
+      {
+        role: "system",
+        content:
+          "You provide structured JSON responses and never include additional commentary.",
+      },
+      { role: "user", content: prompt },
+    ],
+    temperature: DEFAULT_TEMPERATURE,
+    max_output_tokens: Number(process.env.AI_MEAL_PLAN_MAX_OUTPUT ?? "600"),
+  });
+
+  const text = extractTextFromResponse(response);
+  const rankings = safeParseRankings(text);
+
+  if (!rankings.length) {
+    throw new Error("AI response did not contain any rankings.");
+  }
+
+  return rankings;
+}
+
+module.exports = {
+  rankMealPlans,
+  __private: {
+    buildPrompt,
+    safeParseRankings,
+    extractTextFromResponse,
+  },
+};

--- a/backend/test/aiMealPlanSuggestions.test.js
+++ b/backend/test/aiMealPlanSuggestions.test.js
@@ -1,0 +1,204 @@
+process.env.NODE_ENV = "test";
+const { expect } = require("chai");
+
+const mealPlanController = require("../controllers/mealPlanController");
+const MealPlan = require("../models/MealPlan");
+const User = require("../models/User");
+const Profile = require("../models/Profile");
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+const profileFixture = {
+  _id: "profile-1",
+  dietaryPreferences: ["vegan"],
+  goal: "muscle-gain",
+};
+
+describe("mealPlanController.suggestedMealPlans", () => {
+  const originalEnv = {
+    AI_RANKER_CANDIDATE_LIMIT: process.env.AI_RANKER_CANDIDATE_LIMIT,
+    SUGGESTED_MEALPLAN_LIMIT: process.env.SUGGESTED_MEALPLAN_LIMIT,
+  };
+
+  const originalFns = {
+    userFindById: User.findById,
+    profileFindOne: Profile.findOne,
+    mealPlanFind: MealPlan.find,
+    mealPlanAggregate: MealPlan.aggregate,
+  };
+
+  beforeEach(() => {
+    process.env.AI_RANKER_CANDIDATE_LIMIT = "3";
+    process.env.SUGGESTED_MEALPLAN_LIMIT = "3";
+
+    User.findById = () => ({
+      select: () => ({
+        lean: async () => ({ profile: { _id: profileFixture._id } }),
+      }),
+    });
+
+    Profile.findOne = () => ({
+      sort: () => ({ lean: async () => profileFixture }),
+      lean: async () => profileFixture,
+    });
+  });
+
+  afterEach(() => {
+    process.env.AI_RANKER_CANDIDATE_LIMIT = originalEnv.AI_RANKER_CANDIDATE_LIMIT;
+    process.env.SUGGESTED_MEALPLAN_LIMIT = originalEnv.SUGGESTED_MEALPLAN_LIMIT;
+
+    User.findById = originalFns.userFindById;
+    Profile.findOne = originalFns.profileFindOne;
+    MealPlan.find = originalFns.mealPlanFind;
+    MealPlan.aggregate = originalFns.mealPlanAggregate;
+
+    mealPlanController.__resetRankMealPlanService();
+  });
+
+  it("orders meal plans according to AI ranking and surfaces rationales", async () => {
+    const candidatePlans = [
+      { _id: "plan-a", title: "A", dietTags: ["vegan"], goalType: "muscle-gain" },
+      { _id: "plan-b", title: "B", dietTags: ["vegan"], goalType: "muscle-gain" },
+      { _id: "plan-c", title: "C", dietTags: ["vegan"], goalType: "muscle-gain" },
+    ];
+
+    const candidateLimit = Number(process.env.AI_RANKER_CANDIDATE_LIMIT);
+
+    MealPlan.find = () => {
+      const chain = {
+        limitValue: null,
+        sort() {
+          return chain;
+        },
+        limit(value) {
+          chain.limitValue = value;
+          return chain;
+        },
+        async lean() {
+          if (chain.limitValue === candidateLimit) {
+            return candidatePlans;
+          }
+          return [];
+        },
+      };
+      return chain;
+    };
+
+    let aggregateCalls = 0;
+    MealPlan.aggregate = async () => {
+      aggregateCalls += 1;
+      return [];
+    };
+
+    mealPlanController.__setRankMealPlanService(async () => [
+      { id: "plan-b", rationale: "Higher protein for muscle recovery." },
+      { id: "plan-a" },
+      { id: "plan-c" },
+    ]);
+
+    const req = { user: { id: "user-1" } };
+    const res = createResponse();
+
+    await mealPlanController.suggestedMealPlans(req, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.items.map((item) => item._id)).to.deep.equal([
+      "plan-b",
+      "plan-a",
+      "plan-c",
+    ]);
+    expect(res.body.items[0].aiRationale).to.equal(
+      "Higher protein for muscle recovery."
+    );
+    expect(res.body.ai.used).to.be.true;
+    expect(res.body.ai.error).to.be.null;
+    expect(aggregateCalls).to.equal(0);
+  });
+
+  it("falls back to preference ordering when AI ranking fails", async () => {
+    const candidatePlans = [
+      { _id: "plan-x", title: "X", dietTags: ["vegan"], goalType: "muscle-gain" },
+      { _id: "plan-y", title: "Y", dietTags: ["vegan"], goalType: "muscle-gain" },
+    ];
+
+    const candidateLimit = Number(process.env.AI_RANKER_CANDIDATE_LIMIT);
+
+    MealPlan.find = () => {
+      const chain = {
+        limitValue: null,
+        sort() {
+          return chain;
+        },
+        limit(value) {
+          chain.limitValue = value;
+          return chain;
+        },
+        async lean() {
+          if (chain.limitValue === candidateLimit) {
+            return candidatePlans;
+          }
+          return [{ _id: "recent-1", title: "Recent" }];
+        },
+      };
+      return chain;
+    };
+
+    let aggregateCalls = 0;
+    MealPlan.aggregate = async () => {
+      aggregateCalls += 1;
+      if (aggregateCalls === 1) {
+        return [];
+      }
+      return [
+        {
+          _id: "plan-y",
+          title: "Y",
+          dietTags: ["vegan"],
+          goalType: "muscle-gain",
+          score: 5,
+        },
+        {
+          _id: "plan-x",
+          title: "X",
+          dietTags: ["vegan"],
+          goalType: "muscle-gain",
+          score: 3,
+        },
+      ];
+    };
+
+    mealPlanController.__setRankMealPlanService(async () => {
+      throw new Error("LLM offline");
+    });
+
+    const req = { user: { id: "user-2" } };
+    const res = createResponse();
+
+    await mealPlanController.suggestedMealPlans(req, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.ai.used).to.be.false;
+    expect(res.body.ai.error).to.equal("LLM offline");
+    expect(res.body.items.map((item) => item._id)).to.deep.equal([
+      "plan-y",
+      "plan-x",
+    ]);
+    res.body.items.forEach((item) => expect(item.aiRationale).to.equal(null));
+    expect(aggregateCalls).to.equal(2);
+  });
+});

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -376,6 +376,14 @@ function renderMealPlanCard(mp) {
   const p = mp.protein ?? "—";
   const f = mp.fat ?? "—";
   const c = mp.carbs ?? "—";
+  const rationale = mp.aiRationale
+    ? `<div class="ai-rationale" style="background:#f2f6ff;border-left:3px solid #3b82f6;padding:.6rem .8rem;margin:.8rem 0;border-radius:.35rem;">
+        <div style="font-size:.8rem;text-transform:uppercase;letter-spacing:.08em;color:#2563eb;font-weight:600;margin-bottom:.3rem;">AI match insight</div>
+        <div style="font-size:.95rem;color:#1f2937;line-height:1.35;">${escapeHtml(
+          mp.aiRationale
+        )}</div>
+      </div>`
+    : "";
 
   return `
     <article class="card" data-mp-id="${mp._id}">
@@ -395,6 +403,7 @@ function renderMealPlanCard(mp) {
         diet
       )}</div>
       <div class="muted" style="font-size:.9rem;"><strong>Goal:</strong> ${goal}</div>
+      ${rationale}
       <div style="margin-top:.8rem;display:flex;gap:.5rem;">
         <button class="button" data-action="view-mp" data-id="${
           mp._id

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.0.0"
+    "mongoose": "^7.0.0",
+    "openai": "^4.68.4"
   },
   "devDependencies": {
     "chai": "^6.0.1",


### PR DESCRIPTION
## Summary
- add OpenAI SDK dependency and configure the server to surface the API key environment variable
- introduce an AI meal plan ranker service, integrate it into the suggestion controller, and expose rationales to the frontend
- add unit tests covering AI ordering along with the fallback behaviour when the AI service is unavailable

## Testing
- `npx mocha backend/test/aiMealPlanSuggestions.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d23613002c8329a6b28bd3ee0d33a3